### PR TITLE
Update pullstate

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hotkeys-js": "^3.6.14",
     "immer": "^3.2.0",
     "mdi-material-ui": "^6.4.1",
-    "pullstate": "^1.4.0",
+    "pullstate": "^1.15.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-scripts": "3.1.1",

--- a/src/App.css
+++ b/src/App.css
@@ -3,51 +3,62 @@
   font-family: "Roboto", serif;
   text-align: center;
   background: #153250;
-  height: 100vh;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center; }
-  .App * {
-    transition: background 0.3s ease-in-out; }
+  justify-content: center;
+}
+.App * {
+  transition: background 0.3s ease-in-out;
+}
 
 .puzzle-container {
   border-radius: 0.2em;
-  overflow: hidden; }
-  .puzzle-container .row {
-    display: flex;
-    align-items: center; }
-    .puzzle-container .row .cell {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border: 1px solid #e4e4e4;
-      width: 3em;
-      height: 3em;
-      background: white;
-      position: relative; }
-      .puzzle-container .row .cell .set-value {
-        font-size: 1.5em; }
-      .puzzle-container .row .cell.original {
-        background: #f4f5dd;
-        color: rgba(36, 43, 57, 0.75);
-        font-weight: bold; }
-      .puzzle-container .row .cell input {
-        color: #3175bb;
-        text-align: center;
-        font-size: 1.5em;
-        background: none;
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: none; }
-        .puzzle-container .row .cell input::-webkit-inner-spin-button, .puzzle-container .row .cell input::-webkit-outer-spin-button {
-          margin: 0;
-          appearance: none; }
-      .puzzle-container .row .cell.editable:hover {
-        background: #ddeced;
-        border: 1px solid #555968; }
-
-/*# sourceMappingURL=App.css.map */
+  overflow: hidden;
+}
+.puzzle-container .row {
+  display: flex;
+  align-items: center;
+}
+.puzzle-container .row .cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e4e4e4;
+  width: 3em;
+  height: 3em;
+  background: white;
+  position: relative;
+}
+.puzzle-container .row .cell .set-value {
+  font-size: 1.5em;
+}
+.puzzle-container .row .cell.original {
+  background: #f4f5dd;
+  color: rgba(36, 43, 57, 0.75);
+  font-weight: bold;
+}
+.puzzle-container .row .cell input {
+  color: #3175bb;
+  text-align: center;
+  font-size: 1.5em;
+  background: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+.puzzle-container .row .cell input::-webkit-inner-spin-button, .puzzle-container .row .cell input::-webkit-outer-spin-button {
+  margin: 0;
+  appearance: none;
+}
+.puzzle-container .row .cell.editable:hover {
+  background: #ddeced;
+  border: 1px solid #555968;
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -3,7 +3,10 @@
   font-family: "Roboto", serif;
   text-align: center;
   background: #153250;
-  height: 100vh;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
   width: 100%;
   display: flex;
   align-items: center;
@@ -43,7 +46,8 @@
       }
 
       input {
-        &::-webkit-inner-spin-button, &::-webkit-outer-spin-button {
+        &::-webkit-inner-spin-button,
+        &::-webkit-outer-spin-button {
           margin: 0;
           appearance: none;
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,11 +37,8 @@ function runFireworks() {
 }
 
 const App: React.FC = () => {
-  const [started, finished] = useStoreState(PuzzleStore, (s) => [
-    s.startedPuzzle,
-    s.finishedPuzzle,
-  ]);
-
+  const finished = useStoreState(PuzzleStore, (s) => s.finishedPuzzle);
+  const started = useStoreState(PuzzleStore, (s) => s.startedPuzzle);
   const canUndo = useStoreState(UndoStore, (s) => s.undoStack.length > 0);
   const canRedo = useStoreState(UndoStore, (s) => s.redoStack.length > 0);
 

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,5 +1,5 @@
+import { useStoreState } from "pullstate";
 import React, { CSSProperties } from "react";
-import { useStoreStateOpt } from "pullstate";
 import { PuzzleActions, PuzzleStore } from "../pullstate/PuzzleStore";
 
 export interface ICellProps {
@@ -10,10 +10,16 @@ export interface ICellProps {
 const borderStyle = `1px solid #667788`;
 
 export const Cell = ({ x, y }: ICellProps) => {
-  const [filledBlock, originalFilled] = useStoreStateOpt(PuzzleStore, [
-    ["filledBlocks", y, x],
-    ["originalFilledBlocks", y, x],
-  ]);
+  const filledBlock = useStoreState(
+    PuzzleStore,
+    (s) => (s.startedPuzzle ? s.filledBlocks[y][x] : ""),
+    [x, y]
+  );
+  const originalFilled = useStoreState(
+    PuzzleStore,
+    (s) => (s.startedPuzzle ? s.originalFilledBlocks[y][x] : ""),
+    [x, y]
+  );
 
   const style: CSSProperties = {
     userSelect: "none",
@@ -39,9 +45,16 @@ export const Cell = ({ x, y }: ICellProps) => {
   const filledValue = filledBlock !== "." ? filledBlock : "";
 
   return (
-    <div style={style} className={`cell ${wasOriginal ? `original` : `editable`}`}>
+    <div
+      style={style}
+      className={`cell ${wasOriginal ? `original` : `editable`}`}
+    >
       {!wasOriginal && (
-        <input type={"number"} value={filledValue} onChange={event => PuzzleActions.editCell(x, y, event.target.value)} />
+        <input
+          type={"number"}
+          value={filledValue}
+          onChange={(event) => PuzzleActions.editCell(x, y, event.target.value)}
+        />
       )}
       {wasOriginal && <span className={`set-value`}>{filledValue}</span>}
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
+import { PuzzleStore } from "./pullstate/PuzzleStore";
+import { registerInDevtools } from "pullstate";
+import { UndoStore } from "./pullstate/PuzzleUndoRedo";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
 serviceWorker.unregister();
+registerInDevtools({ PuzzleStore, UndoStore });

--- a/src/pullstate/PuzzleStore.ts
+++ b/src/pullstate/PuzzleStore.ts
@@ -25,7 +25,7 @@ PuzzleStore.listenToPatches((patches: Patch[], inversePatches: Patch[]) => {
 
   if (filteredPatches.length > 0) {
     const filteredInversePatches = patchesFilter(inversePatches);
-    PuzzleUndoRedo.usePatchesForUndoRedo(filteredPatches, filteredInversePatches);
+    PuzzleUndoRedo.addChanges(filteredPatches, filteredInversePatches);
   }
 });
 
@@ -33,14 +33,14 @@ PuzzleStore.listenToPatches((patches: Patch[], inversePatches: Patch[]) => {
 
 // If our board has changed, check if the user has won the game
 PuzzleStore.createReaction(
-  s => s.filledBlocks,
+  (s) => s.filledBlocks,
   (watched, s, o) => {
     if (o.startedPuzzle && watched.length > 0) {
       const boardString = sudoku.board_grid_to_string(watched);
       const solvedBoardString = sudoku.solve(boardString);
 
       if (solvedBoardString) {
-        console.log(`Avert your eyes! - The solved Sudoku:`)
+        console.log(`Avert your eyes! - The solved Sudoku:`);
         sudoku.print_board(solvedBoardString);
       }
 
@@ -56,7 +56,7 @@ function generateNewSudoku(level: "easy" | "medium" | "hard" | "very-hard") {
   const filledBlocks: string[][] = sudoku.board_string_to_grid(sudokuString);
   const originalFilled: string[][] = sudoku.board_string_to_grid(sudokuString);
 
-  PuzzleStore.update(s => {
+  PuzzleStore.update((s) => {
     s.filledBlocks = filledBlocks;
     s.originalFilledBlocks = originalFilled;
     s.startedPuzzle = true;
@@ -70,7 +70,7 @@ function editCell(x: number, y: number, value: string) {
     if (value === "") {
       value = ".";
     }
-    PuzzleStore.update(s => {
+    PuzzleStore.update((s) => {
       s.filledBlocks[y][x] = value;
     });
   }
@@ -78,7 +78,7 @@ function editCell(x: number, y: number, value: string) {
 
 function reset() {
   PuzzleUndoRedo.reset();
-  PuzzleStore.update(s => {
+  PuzzleStore.update((s) => {
     s.startedPuzzle = false;
     s.finishedPuzzle = false;
   });
@@ -92,12 +92,12 @@ function clearBoard() {
         s.filledBlocks[y][x] = cell;
       }
     }
-  }, PuzzleUndoRedo.usePatchesForUndoRedo);
+  }, PuzzleUndoRedo.addChanges);
 }
 
 export const PuzzleActions = {
   generateNewSudoku,
   editCell,
   reset,
-  clearBoard
+  clearBoard,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4004,6 +4004,11 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-glob@^2.0.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -4860,6 +4865,11 @@ immer@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-3.2.0.tgz#53686471e9dd2b070e0fb5500c6fdecd3a99375f"
   integrity sha512-+a2R8z9eELHst6aht++nzVzJ8LJ+Hsg49qttfg9Kc/vmoxEdPXw5/rV6+4DYWGgnq+B36KbLr4OTaGtS9mDjtg==
+
+immer@^7.0.1:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.5.tgz#8af347db5b60b40af8ae7baf1784ea4d35b5208e"
+  integrity sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -8084,12 +8094,13 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-pullstate@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/pullstate/-/pullstate-1.4.0.tgz#0a4e1a5264c0873dadc6fe0c252ad98e46534a04"
-  integrity sha512-LSGW8FaInZPJFVOPfoYyaTCyYotn5omFDosBPTCKQnrwDhFrAH9EtmFCfT7V3BtN5moSXUHew9q2K9C5H1vhrQ==
+pullstate@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/pullstate/-/pullstate-1.15.2.tgz#5c8d0d09a7dd08669146beebf9d44024c3f41270"
+  integrity sha512-Ut9CFLkZqsWYZy9hWU6eKe2s02PR6jplBqZf1ZYrfu/3R3KKjqnzHPCR+49wEr2JYsAzTSTOcJYGZYt2LDkc/A==
   dependencies:
-    fast-deep-equal "^2.0.1"
+    fast-deep-equal "^3.1.3"
+    immer "^7.0.1"
 
 pump@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
I hope you don't mind these changes, but I fixed some minor things while testing the devtools. One thing I noticed is that when a previous state is "activated" using the devtools the change can cause unexpected errors because the order in which listeners are notified might not be the order a developer expects: In this case the `Cell` component threw an error because its listener was called before it was unmounted because the board was deleted, but the nested component updated first - that should be fixed checking whether the game started.

I updated `pullstate` and fixed some small issues / added things I considered an improvement:

- Updated `pullstate` from 1.4.0 to 1.15.2
- Registered the two stores using the new devtools feature
- Converted the undo / redo global state to a separate store - I am not sure if that's the correct thing to do but it allows us to disable the undo / redo buttons if there are no changes left.
- Fixed a minor layout issue that occurred when the window height was not sufficient to display the entire grid
